### PR TITLE
allow pre-loading a notebook with JUPYTER_NOTEBOOK_X_INCLUDE

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ if [[ "x$JUPYTER_NOTEBOOK_PASSWORD" != "x" ]]; then
 fi
 
 if [[ -n "$JUPYTER_NOTEBOOK_X_INCLUDE" ]]; then
-    (cd /notebook; curl -O $JUPYTER_NOTEBOOK_X_INCLUDE)
+    curl -O $JUPYTER_NOTEBOOK_X_INCLUDE
 fi
 
 export PYTHONPATH=$SPARK_HOME/python:$(echo $SPARK_HOME/python/lib/py4j-*-src.zip)

--- a/start.sh
+++ b/start.sh
@@ -5,5 +5,9 @@ if [[ "x$JUPYTER_NOTEBOOK_PASSWORD" != "x" ]]; then
     echo "c.NotebookApp.password = u'$HASH'" >> /home/$NB_USER/.jupyter/jupyter_notebook_config.py
 fi
 
+if [[ -n "$JUPYTER_NOTEBOOK_X_INCLUDE" ]]; then
+    (cd /notebook; curl -O $JUPYTER_NOTEBOOK_X_INCLUDE)
+fi
+
 export PYTHONPATH=$SPARK_HOME/python:$(echo $SPARK_HOME/python/lib/py4j-*-src.zip)
 exec jupyter notebook


### PR DESCRIPTION
JUPYTER_NOTEBOOK_X_INCLUDE should be a curl'able URL. when provided in
the container's environment, the URL will be downloaded into /notebook
and available to the notebook user