### PR TITLE
Adding a way to bypass the notebook token. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 0527A9B7 && gpg --verify /tini.asc
 ADD start.sh /start.sh
+ADD ready.sh /ready.sh
 
 RUN chmod +x /tini /start.sh
 

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,11 @@ clean:
 	docker rmi -f $(LOCAL_IMAGE)
 
 run:
-	docker run -p 8888:8888 -e JUPYTER_NOTEBOOK_PASSWORD=developer $(USER)/base-notebook
+	docker run -ti --rm -p 8888:8888 -e JUPYTER_NOTEBOOK_DISABLE_TOKEN=true $(USER)/base-notebook
 
 test:
-	docker run -d --name test-base-notebook -p 8888:8888 -e JUPYTER_NOTEBOOK_PASSWORD=developer $(USER)/base-notebook
+	-docker rm -f test-base-notebook || true
+	docker run -d --name test-base-notebook -p 8888:8888 -e JUPYTER_NOTEBOOK_DISABLE_TOKEN=true $(USER)/base-notebook
 	sleep $(WAIT_TIME)
 	./ready.sh && echo "Test completed successfully!"
-	docker rm -f test-base-notebook
+	-docker rm -f test-base-notebook || true

--- a/ready.sh
+++ b/ready.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 
-http_code=`curl -s -o /dev/null -w "%{http_code}" http://localhost:8888/api`
-[[ "$http_code" -lt "200" || "$http_code" -gt "299" ]] && exit 1
+checkUrl() {
+  [[ $# -lt 1 ]] && echo "usage: checkUrl <url>" && return
+  echo $1
+  http_code=`curl -s -o /dev/null -w "%{http_code}" $1`
+  [[ "$http_code" -lt "200" || "$http_code" -gt "299" ]] && exit 1
+}
+
+# this endpoint should be reachable even without auth
+checkUrl "http://localhost:8888/api"
+
+# check this endpoint if the authN is completely disabled
+if [[ "$JUPYTER_NOTEBOOK_DISABLE_TOKEN" == "true" && -z "$JUPYTER_NOTEBOOK_PASSWORD" ]]; then
+  checkUrl "http://localhost:8888/tree"
+fi
 
 exit 0

--- a/start.sh
+++ b/start.sh
@@ -5,6 +5,10 @@ if [[ "x$JUPYTER_NOTEBOOK_PASSWORD" != "x" ]]; then
     echo "c.NotebookApp.password = u'$HASH'" >> /home/$NB_USER/.jupyter/jupyter_notebook_config.py
 fi
 
+if [[ "$JUPYTER_NOTEBOOK_DISABLE_TOKEN" == "true" ]]; then
+    echo "c.NotebookApp.token = ''" >> /home/$NB_USER/.jupyter/jupyter_notebook_config.py
+fi
+
 if [[ -n "$JUPYTER_NOTEBOOK_X_INCLUDE" ]]; then
     curl -O $JUPYTER_NOTEBOOK_X_INCLUDE
 fi


### PR DESCRIPTION
Also extending the readiness check and making it part of the base image. 

By default everything is the same as before. Only if the `JUPYTER_NOTEBOOK_DISABLE_TOKEN` is set to `true`, the token will be set to an empty string, this means it will not be generated/required by Jupyter. If the `JUPYTER_NOTEBOOK_PASSWORD` is set to an non empty string, this password will be required during the first access to the notebook (no matter, if the token is generated/set or disabled). In other words, setting the both abovementioned env variables at the same time doesn't make sense.

If there is no authN, the `ready.sh` script will check also the endpoint with the notebooks (`/tree`). Also adding the `ready.sh` to the image so that it can be used in the openshift for ready/live checks.